### PR TITLE
Update utils.py for py3.9+ compatibility

### DIFF
--- a/senteval/utils.py
+++ b/senteval/utils.py
@@ -86,10 +86,10 @@ def get_optimizer(s):
         raise Exception('Unknown optimization method: "%s"' % method)
 
     # check that we give good parameters to the optimizer
-    expected_args = inspect.getargspec(optim_fn.__init__)[0]
-    assert expected_args[:2] == ['self', 'params']
-    if not all(k in expected_args[2:] for k in optim_params.keys()):
+    expected_args = inspect.getfullargspec(optim_fn.__init__)
+    assert expected_args.args[:2] == ['self', 'params']
+    if not all(k in expected_args.args[2:] for k in optim_params.keys()):
         raise Exception('Unexpected parameters: expected "%s", got "%s"' % (
-            str(expected_args[2:]), str(optim_params.keys())))
+            str(expected_args.args[2:]), str(optim_params.keys())))
 
     return optim_fn, optim_params

--- a/senteval/utils.py
+++ b/senteval/utils.py
@@ -87,9 +87,9 @@ def get_optimizer(s):
 
     # check that we give good parameters to the optimizer
     expected_args = inspect.getfullargspec(optim_fn.__init__)
-    assert expected_args.args[:2] == ['self', 'params']
-    if not all(k in expected_args.args[2:] for k in optim_params.keys()):
+    assert expected_args[:2] == ['self', 'params']
+    if not all(k in expected_args[2:] for k in optim_params.keys()):
         raise Exception('Unexpected parameters: expected "%s", got "%s"' % (
-            str(expected_args.args[2:]), str(optim_params.keys())))
+            str(expected_args[2:]), str(optim_params.keys())))
 
     return optim_fn, optim_params


### PR DESCRIPTION
Running the evaluation with Python 3.10.5 results in:
`ValueError: Function has keyword-only parameters or annotations, use inspect.signature() API which can support them`

Hence. replacing the legacy `inspect.getargspec` method with `inspect.getfullargspec` method, as per [here](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec):
```
# check that we give good parameters to the optimizer
    expected_args = inspect.getfullargspec(optim_fn.__init__)
    assert expected_args.args[:2] == ['self', 'params']
    if not all(k in expected_args.args[2:] for k in optim_params.keys()):
        raise Exception('Unexpected parameters: expected "%s", got "%s"' % (
            str(expected_args.args[2:]), str(optim_params.keys())))
```

This commit fixes this issue: #88. This fix was originated from this PR #87 which did not get merged after such a long time. Hence I forked this repo and implemented this fix myself.

Tested on Windows with Python 3.10.5. 